### PR TITLE
add `shfmt-mode` callable

### DIFF
--- a/shfmt.el
+++ b/shfmt.el
@@ -72,6 +72,7 @@ the input text.  This means that you should avoid flags like
 ;;;###autoload (autoload 'shfmt-buffer "shfmt" nil t)
 ;;;###autoload (autoload 'shfmt-region "shfmt" nil t)
 ;;;###autoload (autoload 'shfmt-on-save-mode "shfmt" nil t)
+;;;###autoload (autoload 'shfmt-mode "shfmt" nil t)
 (reformatter-define shfmt
   :program shfmt-command
   ;; Pass the filename to `shfmt` as it may influence the Editorconfig pattern "shfmt" picks up


### PR DESCRIPTION
Just as a convenience for fellow `use-package` users. 
Also arguably more easy to guess. 

Previous configuration
```el
(use-package shfmt
  :hook (sh-mode . shfmt-on-save-mode))
```

After change
```el
(use-package shfmt 
  :hook sh-mode)
```

Magical how all those autoloads just work by adding them above the `reformatter-define`