### PR TITLE
Fix invalid list append of shfmt-arguments

### DIFF
--- a/shfmt.el
+++ b/shfmt.el
@@ -82,7 +82,7 @@ Additional arguments from `shfmt-arguments' are also included."
    (list "--filename" input-file)
    (when (and shfmt-respect-sh-basic-offset (boundp 'sh-basic-offset))
      (list "-i" (number-to-string sh-basic-offset)))
-   (list shfmt-arguments)))
+   shfmt-arguments))
 
 
 ;; Commands for reformatting


### PR DESCRIPTION
Commit 87d22ce2fbf6 ("Respect 'sh-basic-offset' for indentation and support indirect buffers") wrongly tried to append the custom list variable `shfmt-arguments` by `list`ing it. This would lead to errors like

  Wrong type argument: stringp, ("-i" "4")

if one sets for example

  (setopt shfmt-arguments '("-i" "4"))

The variable is already a list so remove the
faulty extra `list` call. Fixes #14.

Maybe there should be some tests in place so that this doesn't happen in the future and break user's configs...