### PR TITLE
Fixes #14: Correctly append shfmt-arguments in the shfmt--arg function

### DIFF
--- a/shfmt.el
+++ b/shfmt.el
@@ -82,7 +82,7 @@ Additional arguments from `shfmt-arguments' are also included."
    (list "--filename" input-file)
    (when (and shfmt-respect-sh-basic-offset (boundp 'sh-basic-offset))
      (list "-i" (number-to-string sh-basic-offset)))
-   (list shfmt-arguments)))
+   shfmt-arguments))
 
 
 ;; Commands for reformatting


### PR DESCRIPTION
This pull request fixes this issue: https://github.com/purcell/emacs-shfmt/issues/14


The previous implementation of `shfmt--args` function wrapped `shfmt-arguments` inside a list, resulting in nested lists being passed where strings were expected. This caused the error `Wrong type argument: stringp, ("-i" "4")`.

This commit resolves the issue by correctly appending `shfmt-arguments` as a flat list.
